### PR TITLE
Support detailed time selection in dev auto script

### DIFF
--- a/change-auto-dev.js
+++ b/change-auto-dev.js
@@ -29,9 +29,22 @@
     phase: 'search',             // 'search' | 'finalize'
     laterAllowedHours: [20,21],  // 後ろにずらす時に対象とする時刻（20/21）
     lastReloadAt: 0,
-    minReloadIntervalMs: 7000
+    minReloadIntervalMs: 7000,
+    useDetailedTime: false,
+    detailedHour: 10,
+    detailedMinute: 0
   };
   let state = loadState();
+  if (!Number.isFinite(Number(state.detailedHour))) {
+    state.detailedHour = Number(state.baseHour) || 0;
+  } else {
+    state.detailedHour = Math.min(23, Math.max(0, Math.floor(Number(state.detailedHour))));
+  }
+  if (!Number.isFinite(Number(state.detailedMinute))) {
+    state.detailedMinute = 0;
+  } else {
+    state.detailedMinute = Math.min(59, Math.max(0, Math.floor(Number(state.detailedMinute))));
+  }
   function loadState() {
     try { return Object.assign({}, defaultState, JSON.parse(localStorage.getItem(STATE_KEY) || '{}')); }
     catch { return { ...defaultState }; }
@@ -41,6 +54,11 @@
   /********** 汎用 **********/
   const rand = (a,b)=>Math.random()*(b-a)+a;
   const sleep = (ms)=>new Promise(r=>setTimeout(r,ms));
+  const clampInt = (value,min,max)=>{
+    const n = Math.floor(Number(value));
+    if (!Number.isFinite(n)) return min;
+    return Math.min(max, Math.max(min, n));
+  };
   const isVisible = (el)=>{ const r = el?.getBoundingClientRect?.(); return !!(r && r.width>0 && r.height>0); };
   const isDisabledLike = (el)=> el?.hasAttribute('disabled')
       || el?.getAttribute('aria-disabled') === 'true'
@@ -241,6 +259,13 @@
     function renderTimes(){
       const times = state.direction==='earlier'?[9,10,11,12]:[19,20,21,22]; // -19 センチネル設計は別途
       const box = root.querySelector('#km-time-list');
+      const detailHour = clampInt(state.detailedHour, 0, 23);
+      const detailMinute = clampInt(state.detailedMinute, 0, 59);
+      if (detailHour !== state.detailedHour || detailMinute !== state.detailedMinute) {
+        state.detailedHour = detailHour;
+        state.detailedMinute = detailMinute;
+        saveState();
+      }
       box.innerHTML = `
         <div>現在の予約時刻</div>
         <div style="display:flex;flex-wrap:wrap;gap:6px;margin-top:4px;">
@@ -250,6 +275,23 @@
               <span>${h}時</span>
             </label>
           `).join('')}
+        </div>
+
+        <div style="margin-top:10px;">
+          <label style="display:flex;align-items:center;gap:6px;cursor:pointer;">
+            <input type="checkbox" id="km-use-detailed-time" ${state.useDetailedTime?'checked':''}>
+            <span>詳細な時間を設定する</span>
+          </label>
+          <div style="display:flex;align-items:center;gap:10px;margin-top:6px;${state.useDetailedTime?'':'opacity:0.5;'}">
+            <label style="display:flex;align-items:center;gap:4px;">
+              <input type="number" id="km-detail-hour" min="0" max="23" value="${detailHour}" style="width:52px;" ${state.useDetailedTime?'':'disabled'}>
+              <span>時</span>
+            </label>
+            <label style="display:flex;align-items:center;gap:4px;">
+              <input type="number" id="km-detail-minute" min="0" max="59" value="${detailMinute}" style="width:52px;" ${state.useDetailedTime?'':'disabled'}>
+              <span>分</span>
+            </label>
+          </div>
         </div>
 
         ${state.direction==='later' ? `
@@ -276,6 +318,39 @@
           saveState();
         });
       });
+      const detailToggle = box.querySelector('#km-use-detailed-time');
+      const detailHourInput = box.querySelector('#km-detail-hour');
+      const detailMinuteInput = box.querySelector('#km-detail-minute');
+      if (detailToggle){
+        detailToggle.addEventListener('change',()=>{
+          state.useDetailedTime = detailToggle.checked;
+          if (state.useDetailedTime && (state.detailedHour === null || Number.isNaN(Number(state.detailedHour)))){
+            state.detailedHour = Number(state.baseHour) || 0;
+          }
+          saveState();
+          renderTimes();
+        });
+      }
+      if (detailHourInput){
+        detailHourInput.addEventListener('change',()=>{
+          const v = clampInt(detailHourInput.value,0,23);
+          detailHourInput.value = v;
+          if (state.detailedHour !== v){
+            state.detailedHour = v;
+            saveState();
+          }
+        });
+      }
+      if (detailMinuteInput){
+        detailMinuteInput.addEventListener('change',()=>{
+          const v = clampInt(detailMinuteInput.value,0,59);
+          detailMinuteInput.value = v;
+          if (state.detailedMinute !== v){
+            state.detailedMinute = v;
+            saveState();
+          }
+        });
+      }
     }
 
     function syncUI(){
@@ -442,6 +517,36 @@
     }
     return null;
   }
+  function parseStartTimeFromText(t){
+    if (!t) return null;
+    const s = toHalfWidthDigits(t).replace(/\s/g,'');
+    let m = s.match(/(\d{1,2})[：:](\d{2})/);
+    if (m){
+      const hour = Number(m[1]);
+      const minute = Number(m[2]);
+      if (Number.isInteger(hour) && hour>=0 && hour<=23 && Number.isInteger(minute) && minute>=0 && minute<=59){
+        return { hour, minute };
+      }
+    }
+    m = s.match(/(\d{1,2})時(\d{1,2})分?/);
+    if (m){
+      const hour = Number(m[1]);
+      const minute = Number(m[2]);
+      if (Number.isInteger(hour) && hour>=0 && hour<=23 && Number.isInteger(minute) && minute>=0 && minute<=59){
+        return { hour, minute };
+      }
+    }
+    m = s.match(/(\d{1,2})時/);
+    if (m){
+      const hour = Number(m[1]);
+      if (Number.isInteger(hour) && hour>=0 && hour<=23){
+        return { hour, minute: 0 };
+      }
+    }
+    const hour = parseHourFromText(t);
+    if (hour !== null) return { hour, minute: 0 };
+    return null;
+  }
   function listTimeOptions(menuRoot){
     const items = Array.from(menuRoot.querySelectorAll('[role="option"], li, [data-value]'));
     const results = [];
@@ -454,7 +559,9 @@
                     || /line-through/.test(el.className);
       const hour = parseHourFromText(text);
       const isWheel = /車いす/.test(text); // 車いすは除外
-      results.push({ el, text, hour, disabled, isWheel });
+      const startTime = parseStartTimeFromText(text);
+      const startMinutes = startTime ? (startTime.hour*60 + startTime.minute) : (hour !== null ? hour*60 : null);
+      results.push({ el, text, hour, disabled, isWheel, startMinutes });
     }
     return results;
   }
@@ -499,29 +606,44 @@
     const allowedLater = Array.isArray(state.laterAllowedHours)
       ? state.laterAllowedHours.map(Number)
       : [];
+    const detailedEnabled = Boolean(state.useDetailedTime) && base >= 0;
+    const detailHour = clampInt(state.detailedHour, 0, 23);
+    const detailMinute = clampInt(state.detailedMinute, 0, 59);
+    const baseTimeMinutes = detailHour * 60 + detailMinute;
+    const detailCapable = detailedEnabled && opts.some(o => typeof o.startMinutes === 'number');
 
-    let candidates = opts.filter(o => o.hour !== base);
+    let candidates = opts;
 
-    // 後ろにずらす時の時刻制限
-    if (state.direction === 'later'){
-      // -19 のときは 20時以上だけ
-      if (pre19) candidates = candidates.filter(o => o.hour >= 20);
-      // 20/21の個別指定（チェックが1つ以上あれば適用）
-      if (allowedLater.length > 0) {
-        candidates = candidates.filter(o => allowedLater.includes(o.hour));
+    if (detailCapable){
+      candidates = candidates.filter(o => typeof o.startMinutes === 'number');
+      if (state.direction === 'later'){
+        if (pre19) candidates = candidates.filter(o => o.hour >= 20);
+        if (allowedLater.length > 0) {
+          candidates = candidates.filter(o => allowedLater.includes(o.hour));
+        }
+        candidates = candidates
+          .filter(o => o.startMinutes > baseTimeMinutes)
+          .sort((a,b)=> b.startMinutes - a.startMinutes);
+      } else {
+        candidates = candidates
+          .filter(o => o.startMinutes < baseTimeMinutes)
+          .sort((a,b)=> a.startMinutes - b.startMinutes);
       }
-    }
-
-    if (state.direction === 'earlier'){
-      // 前＝最も早い（min）
-      candidates = candidates
-        .filter(o => o.hour < base)
-        .sort((a,b)=> a.hour - b.hour);
     } else {
-      // 後＝最も遅い（max）
-      candidates = candidates
-        .filter(o => o.hour > base)
-        .sort((a,b)=> b.hour - a.hour);
+      candidates = candidates.filter(o => o.hour !== base);
+      if (state.direction === 'later'){
+        if (pre19) candidates = candidates.filter(o => o.hour >= 20);
+        if (allowedLater.length > 0) {
+          candidates = candidates.filter(o => allowedLater.includes(o.hour));
+        }
+        candidates = candidates
+          .filter(o => o.hour > base)
+          .sort((a,b)=> b.hour - a.hour);
+      } else {
+        candidates = candidates
+          .filter(o => o.hour < base)
+          .sort((a,b)=> a.hour - b.hour);
+      }
     }
 
     if (!candidates.length){


### PR DESCRIPTION
## Summary
- add state and UI controls to enable minute-level reservation targeting when requested
- parse start times from availability options and adjust search logic to honor detailed time settings while preserving hourly behavior otherwise

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9cd96259c8327845aa2082f37a4dc