### PR TITLE
Allow target time selection beyond restricted later hours

### DIFF
--- a/change-auto-dev.js
+++ b/change-auto-dev.js
@@ -759,6 +759,13 @@
     const allowedLater = Array.isArray(state.laterAllowedHours)
       ? state.laterAllowedHours.map(Number)
       : [];
+    const allowedLaterSet = new Set();
+    for (const h of allowedLater){
+      if (Number.isFinite(h)) allowedLaterSet.add(h);
+    }
+    if (allowedLaterSet.size && targetMode && targetHourRaw !== null){
+      allowedLaterSet.add(targetHourRaw);
+    }
     const minutePrecisionAvailable = opts.some(o => o.hasMinutePrecision && typeof o.startMinutes === 'number');
     const detailCapable = detailMode && minuteSpecified && minutePrecisionAvailable;
     const baseTimeMinutes = detailMode ? (detailHour * 60 + detailMinute) : null;
@@ -769,8 +776,8 @@
     let candidates = opts;
 
     const applyLaterHourFilter = () => {
-      if (allowedLater.length > 0) {
-        candidates = candidates.filter(o => allowedLater.includes(o.hour));
+      if (allowedLaterSet.size > 0) {
+        candidates = candidates.filter(o => allowedLaterSet.has(o.hour));
       }
     };
 


### PR DESCRIPTION
## Summary
- expand the later-hour filtering to include specified target hours when a desired time is set
- ensure reservation changes run for all selected target times even if only 20:00/21:00 checkboxes are enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9ff4dd7548327a9b7a5c917f7c889